### PR TITLE
Make expiry mode configurable

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -27,6 +27,12 @@
             <artifactId>datanucleus-core</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/plugin/src/main/java/io/github/nscuro/datanucleus/cache/caffeine/CaffeineCachePropertyNames.java
+++ b/plugin/src/main/java/io/github/nscuro/datanucleus/cache/caffeine/CaffeineCachePropertyNames.java
@@ -20,6 +20,7 @@ package io.github.nscuro.datanucleus.cache.caffeine;
 
 public final class CaffeineCachePropertyNames {
 
+    public static final String PROPERTY_CACHE_L2_CAFFEINE_EXPIRY_MODE = "datanucleus.cache.level2.caffeine.expirymode";
     public static final String PROPERTY_CACHE_L2_CAFFEINE_INITIAL_CAPACITY = "datanucleus.cache.level2.caffeine.initialcapacity";
 
     private CaffeineCachePropertyNames() {

--- a/plugin/src/main/resources/plugin.xml
+++ b/plugin/src/main/resources/plugin.xml
@@ -6,5 +6,6 @@
 
     <extension point="org.datanucleus.persistence_properties">
         <persistence-property name="datanucleus.cache.level2.caffeine.initialcapacity"/>
+        <persistence-property name="datanucleus.cache.level2.caffeine.expirymode"/>
     </extension>
 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,12 @@
 
             <dependency>
                 <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${lib.slf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${lib.slf4j.version}</version>
             </dependency>


### PR DESCRIPTION
Supports `after-access` and `after-write`, and defaults to `after-access` if not specified.