### PR TITLE
Evict all entries when cache is closed

### DIFF
--- a/plugin/src/main/java/io/github/nscuro/datanucleus/cache/caffeine/CaffeineLevel2Cache.java
+++ b/plugin/src/main/java/io/github/nscuro/datanucleus/cache/caffeine/CaffeineLevel2Cache.java
@@ -84,7 +84,7 @@ public class CaffeineLevel2Cache extends AbstractLevel2Cache {
 
     @Override
     public void close() {
-        // Nothing to do.
+        evictAll();
     }
 
     @Override

--- a/test/src/test/java/io/github/nscuro/datanucleus/cache/caffeine/CaffeineCacheTest.java
+++ b/test/src/test/java/io/github/nscuro/datanucleus/cache/caffeine/CaffeineCacheTest.java
@@ -169,6 +169,25 @@ class CaffeineCacheTest {
                 });
     }
 
+    @Test
+    void testClose() {
+        pmf = createPmf(Collections.emptyMap());
+
+        try (final PersistenceManager pm = pmf.getPersistenceManager()) {
+            for (int i = 0; i < 10; i++) {
+                final var person = new Person();
+                person.setName("name-" + i);
+                pm.makePersistent(person);
+            }
+        }
+
+        final var secondLevelCache = (CaffeineLevel2Cache) ((JDODataStoreCache) pmf.getDataStoreCache()).getLevel2Cache();
+        assertThat(secondLevelCache.getSize()).isEqualTo(10);
+
+        secondLevelCache.close();
+        assertThat(secondLevelCache.getSize()).isEqualTo(0);
+    }
+
     private PersistenceManagerFactory createPmf(final Map<String, String> configOverrides) {
         final URL schemaUrl = CaffeineCacheTest.class.getResource("/schema.sql");
         assertThat(schemaUrl).isNotNull();


### PR DESCRIPTION
Replicates behavior of the default `soft` and `weak` caches.